### PR TITLE
fixed "java.io.IOException: Remotely closed" in HTTPS (AHC) #1939

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
@@ -422,7 +422,14 @@ public class SSLBaseFilter extends BaseFilter {
 
             final SslResult result =
                     sslCtx.unwrap(len, input, output, MM_ALLOCATOR);
-            
+
+            output = result.getOutput();
+
+            if (result.isError()) {
+                output.dispose();
+                throw result.getError();
+            }
+
             if (isHandshaking(sslCtx.getSslEngine())) {
                 // is it re-handshake or graceful ssl termination
                 if (result.getSslEngineResult().getStatus() != Status.CLOSED) {
@@ -435,13 +442,6 @@ public class SSLBaseFilter extends BaseFilter {
                 if (input == null) {
                     break;
                 }
-            }
-            
-            output = result.getOutput();
-
-            if (result.isError()) {
-                output.dispose();
-                throw result.getError();
             }
             
             switch (result.getSslEngineResult().getStatus()) {


### PR DESCRIPTION
assigned the unwrapped result to local output before rehandshaking. 