### PR TITLE
Fix NPE when accessing a registered resource

### DIFF
--- a/extras/grizzly-httpservice/src/main/java/org/glassfish/grizzly/osgi/httpservice/OSGiMainHandler.java
+++ b/extras/grizzly-httpservice/src/main/java/org/glassfish/grizzly/osgi/httpservice/OSGiMainHandler.java
@@ -266,7 +266,13 @@ public class OSGiMainHandler extends HttpHandler implements OSGiHandler {
             if (internalPrefix == null) {
                 internalPrefix = "";
             }
-            OSGiServletContext servletContext = mapper.getServletContext(context);
+
+            OSGiServletContext servletContext =
+                    mapper.getServletContext(context);
+            if (servletContext == null) {
+                mapper.addContext(context, null);
+                servletContext = mapper.getServletContext(context);
+            }
 
             mapper.addHttpHandler(alias,
                                   new OSGiResourceHandler(alias,


### PR DESCRIPTION
When registering a resource, OSGiMainHandler.registerResourceHandler may pass a null servletContext to the OSGiResourceHandler constructor. This causes a NPE when accessing the resource, thrown by OSGiResourceHandler.service. The fix is to use the same solution as in OSGiMainHandler.registerFilter, which first checks if the servletContext obtained from the mapper is null. If so, use the mapper to create a new servletContext based on the HttpContext and add it to the mapper.