### PR TITLE
test fixes

### DIFF
--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/FileTransferTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/FileTransferTest.java
@@ -167,7 +167,7 @@ public class FileTransferTest {
         f = File.createTempFile("grizzly-test-", ".tmp");
         new FileOutputStream(f).write(1);
         
-        if (f.setReadable(false)) { // skip this check if setReadable returned false
+        if (f.setReadable(false) && !f.canRead()) { // skip this check if setReadable returned false
             try {
                 new FileTransfer(f, 0, 1);
                 fail("Expected IllegalArgumentException to be thrown, f.setReadable(false); FileTransfer(f, 0, 1)");

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/FileTransferTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/FileTransferTest.java
@@ -132,7 +132,7 @@ public class FileTransferTest {
     public void negativeFileTransferAPITest() throws Exception {
         try {
             new FileTransfer(null);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(null)");
         } catch (NullPointerException npe) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);
@@ -140,7 +140,7 @@ public class FileTransferTest {
 
         try {
             new FileTransfer(null, 0, 1);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(null, 0, 1)");
         } catch (IllegalArgumentException iae) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);
@@ -149,7 +149,7 @@ public class FileTransferTest {
         File f = new File("foo");
         try {
             new FileTransfer(f, 0, 1);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(new File('foo'), 0, 1");
         } catch (IllegalArgumentException iae) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);
@@ -158,7 +158,7 @@ public class FileTransferTest {
         f = new File(System.getProperty("java.io.tmpdir"));
         try {
             new FileTransfer(f, 0, 1);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(new File(System.getProperty(\"java.io.tmpdir\")), 0, 1)");
         } catch (IllegalArgumentException iae) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);
@@ -170,7 +170,7 @@ public class FileTransferTest {
         if (f.setReadable(false)) { // skip this check if setReadable returned false
             try {
                 new FileTransfer(f, 0, 1);
-                fail("Expected IllegalArgumentException to be thrown");
+                fail("Expected IllegalArgumentException to be thrown, f.setReadable(false); FileTransfer(f, 0, 1)");
             } catch (IllegalArgumentException iae) {
                 //noinspection ResultOfMethodCallIgnored
                 f.setReadable(true);
@@ -181,7 +181,7 @@ public class FileTransferTest {
 
         try {
             new FileTransfer(f, -1, 1);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(f, -1, 1)");
         } catch (IllegalArgumentException iae) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);
@@ -189,7 +189,7 @@ public class FileTransferTest {
 
         try {
             new FileTransfer(f, 0, -1);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(f, 0, -1)");
         } catch (IllegalArgumentException iae) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);
@@ -197,7 +197,7 @@ public class FileTransferTest {
 
         try {
             new FileTransfer(f, 2, 1);
-            fail("Expected IllegalArgumentException to be thrown");
+            fail("Expected IllegalArgumentException to be thrown, FileTransfer(f, 2, 1)");
         } catch (IllegalArgumentException iae) {
         } catch (Exception e) {
             fail("Unexpected exception type: " + e);

--- a/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormatTest.java
+++ b/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormatTest.java
@@ -48,6 +48,7 @@ import static org.glassfish.grizzly.http.Method.GET;
 import static org.glassfish.grizzly.http.Protocol.HTTP_1_1;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Locale;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -156,13 +157,14 @@ public class ApacheLogFormatTest {
     @Test
     public void testBasicFormats() {
         final Response response = mockSimpleResponse();
+        Locale.setDefault(Locale.US);
 
-        assertEquals(ApacheLogFormat.COMMON_UTC        .unsafeFormat(response, date, nanos), "remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567");
-        assertEquals(ApacheLogFormat.COMBINED_UTC      .unsafeFormat(response, date, nanos), "remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567 \"http://referer/\" \"Test-User-Agent\"");
-        assertEquals(ApacheLogFormat.VHOST_COMMON_UTC  .unsafeFormat(response, date, nanos), "server-name remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567");
-        assertEquals(ApacheLogFormat.VHOST_COMBINED_UTC.unsafeFormat(response, date, nanos), "server-name remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567 \"http://referer/\" \"Test-User-Agent\"");
-        assertEquals(ApacheLogFormat.REFERER_UTC       .unsafeFormat(response, date, nanos), "http://referer/ -> /test/path");
-        assertEquals(ApacheLogFormat.AGENT_UTC         .unsafeFormat(response, date, nanos), "Test-User-Agent");
+        assertEquals("remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567", ApacheLogFormat.COMMON_UTC.unsafeFormat(response, date, nanos));
+        assertEquals("remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567 \"http://referer/\" \"Test-User-Agent\"", ApacheLogFormat.COMBINED_UTC.unsafeFormat(response, date, nanos));
+        assertEquals("server-name remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567", ApacheLogFormat.VHOST_COMMON_UTC.unsafeFormat(response, date, nanos));
+        assertEquals("server-name remote-host - remote-user [2014/Jan/15:23:45:12 +0000] \"GET /test/path?testing=true HTTP/1.1\" 210 1234567 \"http://referer/\" \"Test-User-Agent\"", ApacheLogFormat.VHOST_COMBINED_UTC.unsafeFormat(response, date, nanos));
+        assertEquals("http://referer/ -> /test/path", ApacheLogFormat.REFERER_UTC.unsafeFormat(response, date, nanos));
+        assertEquals("Test-User-Agent", ApacheLogFormat.AGENT_UTC.unsafeFormat(response, date, nanos));
     }
 
     @Test


### PR DESCRIPTION
This PR has test fixes for two things.

* The negativeFileTransferTest can fail in a very edgy-case where the test is run in docker and the file system is a separate docker volume. Apparently the file.setReadable(false) returns true _even_ though the file is still readable. So just add a check too see if the file is still readable and if so skip the test. I also added some more information on the test asserts to make it more visible exactly what assert failed.

* TheApache log format test fails if the Locale is not US (or english speaking at least) since the abbreviated month names are used and those a localized. So the tests sets the local before checking the output of the log formatter. I also switch the 'expected' value with the 'actual' value to the correct positions in the assert statement.