### PR TITLE
UnsafeAttributeHolder does not respect an initializer if a holder has no attributes yet

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/UnsafeAttributeHolder.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/UnsafeAttributeHolder.java
@@ -82,7 +82,7 @@ final class UnsafeAttributeHolder implements AttributeHolder {
     public Object getAttribute(final String name,
             final NullaryFunction initializer) {
         
-        if (!isSet) {
+        if (!isSet && initializer == null) {
             return null;
         }
         
@@ -264,7 +264,7 @@ final class UnsafeAttributeHolder implements AttributeHolder {
         @Override
         public Object getAttribute(final int index,
                 final NullaryFunction initializer) {
-            if (!isSet) {
+            if (!isSet && initializer == null) {
                 return null;
             }
             

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
@@ -47,6 +47,7 @@ import org.glassfish.grizzly.attributes.Attribute;
 import org.glassfish.grizzly.attributes.AttributeBuilder;
 import org.glassfish.grizzly.attributes.AttributeHolder;
 import org.glassfish.grizzly.attributes.DefaultAttributeBuilder;
+import org.glassfish.grizzly.utils.NullaryFunction;
 
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -119,5 +120,42 @@ public class AttributesTest {
         for (int i = 1; i < attrCount - 1; i++) {
             assertTrue(attrNames.contains(attrs[i].name()));
         }
+    }
+
+    @Test
+    public void testAttributeGetWithNullaryFunctionOnEmptyHolder() {
+        AttributeBuilder builder = new DefaultAttributeBuilder();
+        AttributeHolder holder = isSafe
+                ? builder.createSafeAttributeHolder()
+                : builder.createUnsafeAttributeHolder();
+
+        final Attribute<String> attr = builder.createAttribute(
+                "attribute",
+                new NullaryFunction<String>() {
+                    @Override
+                    public String evaluate() {
+                        return "default";
+                    }
+                }
+        );
+
+        assertNull(attr.peek(holder));
+        assertEquals("default", attr.get(holder));
+        assertTrue(attr.isSet(holder));
+        assertEquals("default", attr.peek(holder));
+    }
+
+    @Test
+    public void testAttributeGetWithoutInitializerOnEmptyHolder() {
+        AttributeBuilder builder = new DefaultAttributeBuilder();
+        AttributeHolder holder = isSafe
+                ? builder.createSafeAttributeHolder()
+                : builder.createUnsafeAttributeHolder();
+
+        final Attribute<String> attr = builder.createAttribute("attribute");
+
+        assertNull(attr.peek(holder));
+        assertEquals(null, attr.get(holder));
+        assertFalse(attr.isSet(holder));
     }
 }


### PR DESCRIPTION
The behavior of UnsafeAttributeHolder should be similar to IndexedAttributeHolder.